### PR TITLE
fix: update view on selection update

### DIFF
--- a/projects/ngx-tiptap/src/lib/editor.directive.ts
+++ b/projects/ngx-tiptap/src/lib/editor.directive.ts
@@ -96,6 +96,9 @@ export class EditorDirective implements OnInit, AfterViewInit, ControlValueAcces
 
     // register update handler to listen to changes on update
     this.editor.on('update', this.handleChange);
+
+    // Needed for ChangeDetectionStrategy.OnPush to get notified
+    this.editor.on('selectionUpdate', () => this.changeDetectorRef.markForCheck())
   }
 
   ngAfterViewInit(): void {


### PR DESCRIPTION
Update view on `selectionUptade` so consumers get notified when using OnPush change detection.

Fixes: #61 